### PR TITLE
Fix require-js css

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,6 @@ module.exports = function (grunt) {
 	];
 
 	var jsCssObjs = [
-		'plugins/dialog-polyfill/dialog-polyfill'
 		//'js-css/band_imagery',
 		//'js-css/display-font',
 		//'js-css/events',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -138,7 +138,7 @@ module.exports = function (grunt) {
 			{
 				name: 'all',
 				create: true,
-				include: polyfillMods.concat('main'),
+				include: polyfillMods.concat(['main', 'require-css/css']),
 				exclude: ['require-css/normalize']
 			}
 		],

--- a/wdn/templates_5.0/js/dialog.js
+++ b/wdn/templates_5.0/js/dialog.js
@@ -1,7 +1,6 @@
 define([
   'plugins/dialog-polyfill/dialog-polyfill',
-  'wdn'
-], function(dialogPolyfill, wdn) {
-  wdn.loadCSS('css!plugins/dialog-polyfill/dialog-polyfill');
+  'css!plugins/dialog-polyfill/dialog-polyfill.css'
+], function(dialogPolyfill) {
   return dialogPolyfill;
 });


### PR DESCRIPTION
require-js css was not working because the r.js config didn't know to include it. In 4.1, [unlalert.js had a require-css reference](https://github.com/unl/wdntemplates/blob/develop/wdn/templates_4.1/scripts/unlalert.js#L4), which told the r.js config to load the require-css dependency into all.js. We don't have unlalert.js yet in 5.0, so require-css wasn't being automatically detected as a dependancy.

This ensures that require-css is always loaded and uses the functionality in the dialog polypill module. 